### PR TITLE
Fix preview grid stale cache issues for file updates

### DIFF
--- a/src/filegrid.tsx
+++ b/src/filegrid.tsx
@@ -217,7 +217,7 @@ export function FileGrid({ bucketName, onFilesChange, refreshTrigger = 0 }: File
         case 'size':
           result = a.size - b.size
           break
-        case 'type':
+        case 'type': {
           const typeA = getFileExtension(a.key)
           const typeB = getFileExtension(b.key)
           result = typeA.localeCompare(typeB)
@@ -225,11 +225,13 @@ export function FileGrid({ bucketName, onFilesChange, refreshTrigger = 0 }: File
             result = a.key.localeCompare(b.key)
           }
           break
-        case 'uploaded':
+        }
+        case 'uploaded': {
           const dateA = new Date(a.uploaded).getTime()
           const dateB = new Date(b.uploaded).getTime()
           result = dateA - dateB
           break
+        }
       }
 
       return sortState.direction === 'asc' ? result : -result
@@ -249,9 +251,10 @@ export function FileGrid({ bucketName, onFilesChange, refreshTrigger = 0 }: File
       setPaginationState(prev => ({ ...prev, isLoading: true, hasError: false }))
       
       const response = await api.listFiles(
-        bucketName, 
-        reset ? undefined : paginatedFiles.cursor, 
-        ITEMS_PER_PAGE
+        bucketName,
+        reset ? undefined : paginatedFiles.cursor,
+        ITEMS_PER_PAGE,
+        { skipCache: reset }
       )
 
       if (!mountedRef.current) return
@@ -426,6 +429,7 @@ export function FileGrid({ bucketName, onFilesChange, refreshTrigger = 0 }: File
       setShouldRefresh(true)
       onFilesChange?.()
     } catch (err) {
+      console.error('Failed to delete selected files:', err)
       setError('Failed to delete one or more files')
     }
   }, [bucketName, selectedFiles, onFilesChange])

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -25,6 +25,15 @@ interface FileListResponse {
   pagination: PaginationInfo
 }
 
+interface ListFilesOptions {
+  skipCache?: boolean
+}
+
+interface CloudflareBucket {
+  name: string
+  creation_date: string
+}
+
 interface DownloadOptions {
   asZip?: boolean
   onProgress?: ProgressCallback
@@ -366,7 +375,7 @@ class APIService {
     }
     
     const data = await response.json()
-    return data.result.buckets.map((bucket: any) => ({
+    return data.result.buckets.map((bucket: CloudflareBucket) => ({
       name: bucket.name,
       created: bucket.creation_date
     }))
@@ -403,13 +412,18 @@ class APIService {
   async listFiles(
     bucketName: string,
     cursor?: string,
-    limit: number = 20
+    limit: number = 20,
+    options: ListFilesOptions = {}
   ): Promise<FileListResponse> {
     const url = new URL(`${WORKER_API}/api/files/${bucketName}`)
     if (cursor) {
       url.searchParams.set('cursor', cursor)
     }
     url.searchParams.set('limit', limit.toString())
+
+    if (options.skipCache) {
+      url.searchParams.set('skipCache', 'true')
+    }
 
     const response = await fetch(url, {
       headers: this.getHeaders()


### PR DESCRIPTION
## Summary
- add API options to bypass cached file listings after uploads and deletions
- version signed download URLs and disable caching on the worker so previews refresh immediately
- make the file grid refresh call the cache-busting path and log failed deletions for easier debugging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f463890b048324bb17d6a52b16e7c5