### PR TITLE
chore: refresh dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,30 +11,30 @@
   },
   "dependencies": {
     "jszip": "^3.10.1",
-    "lucide-react": "^0.461.0",
+    "lucide-react": "^0.546.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-dropzone": "^14.3.5"
+    "react-dropzone": "^14.3.8"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",
-    "@cloudflare/workers-types": "^4.20240208.0",
-    "@eslint/js": "^9.13.0",
-    "@types/node": "^22.10.0",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.3",
-    "esbuild": "^0.25.10",
-    "eslint": "^9.36.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-react-refresh": "^0.4.14",
-    "globals": "^15.11.0",
-    "typescript": "~5.6.2",
-    "typescript-eslint": "^8.11.0",
+    "@cloudflare/workers-types": "^4.20251011.0",
+    "@eslint/js": "^9.38.0",
+    "@types/node": "^22.18.11",
+    "@types/react": "^18.3.26",
+    "@types/react-dom": "^18.3.7",
+    "@vitejs/plugin-react": "^4.7.0",
+    "esbuild": "^0.25.11",
+    "eslint": "^9.38.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "globals": "^15.15.0",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.46.1",
     "vite": "^5.4.20",
     "wrangler": "^4.40.3"
   },
   "overrides": {
-    "esbuild": "^0.25.10"
+    "esbuild": "^0.25.11"
   }
 }


### PR DESCRIPTION
## Summary
- update runtime dependencies to the latest compatible releases
- bump tooling-related devDependencies, including TypeScript and ESLint packages
- align the esbuild override with the updated version

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f4670380848324b59d81bc27d3d864