### PR TITLE
Feature: Force delete non-empty R2 buckets (Issue #11)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1288,3 +1288,86 @@
     padding-left: 1.25rem;
   }
 }
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal-dialog {
+  background: #1F2937;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 450px;
+  width: 100%;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+  border: 1px solid #374151;
+}
+
+.modal-dialog h2 {
+  margin: 0 0 1rem 0;
+  color: #FFFFFF;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.modal-dialog p {
+  margin: 0.75rem 0;
+  color: #D1D5DB;
+  line-height: 1.5;
+}
+
+.modal-dialog strong {
+  color: #FFFFFF;
+  font-weight: 600;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.modal-button {
+  flex: 1;
+  padding: 0.625rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.modal-button.cancel {
+  background: #374151;
+  color: #FFFFFF;
+}
+
+.modal-button.cancel:hover:not(:disabled) {
+  background: #4B5563;
+}
+
+.modal-button.delete {
+  background: #DC2626;
+  color: #FFFFFF;
+}
+
+.modal-button.delete:hover:not(:disabled) {
+  background: #B91C1C;
+}
+
+.modal-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -420,8 +420,13 @@ class APIService {
     return data.result
   }
 
-  async deleteBucket(name: string) {
-    const response = await fetch(`${WORKER_API}/api/buckets/${name}`, 
+  async deleteBucket(name: string, options: { force?: boolean } = {}) {
+    const url = new URL(`${WORKER_API}/api/buckets/${name}`)
+    if (options.force) {
+      url.searchParams.set('force', 'true')
+    }
+    
+    const response = await fetch(url.toString(), 
       this.getFetchOptions({
         method: 'DELETE',
         headers: this.getHeaders()


### PR DESCRIPTION
- Add force delete endpoint support in worker
- Update API service to pass force parameter
- Add confirmation dialog for non-empty buckets
- Display file count in confirmation dialog
- Batch delete all files before deleting bucket
- Handle errors gracefully with retry support
- Add modal styling for confirmation UI