### PR TITLE
Add custom SVG icons for Office docs, data files, and archives

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1083,7 +1083,10 @@
 
 .file-type-icon {
   width: 40%;
-  height: 40%;  
+  height: 40%;
+  /* Ensure consistent rendering */
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .file-info {

--- a/src/filegrid.tsx
+++ b/src/filegrid.tsx
@@ -86,16 +86,132 @@ const isVideoFile = (filename: string): boolean => {
 const getFileTypeIcon = (filename: string): JSX.Element => {
   const ext = getFileExtension(filename)
   
-  if (ext === 'pdf') {
+  // Excel files - spreadsheet with grid pattern
+  if (ext === 'xls' || ext === 'xlsx') {
     return (
-      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="4" y="3" width="16" height="18" rx="2" />
+        <line x1="4" y1="8" x2="20" y2="8" />
+        <line x1="4" y1="13" x2="20" y2="13" />
+        <line x1="4" y1="18" x2="20" y2="18" />
+        <line x1="10" y1="8" x2="10" y2="21" />
+        <line x1="15" y1="8" x2="15" y2="21" />
+      </svg>
+    )
+  }
+  
+  // PowerPoint files - presentation slide icon
+  if (ext === 'ppt' || ext === 'pptx') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="4" y="4" width="16" height="12" rx="1" />
+        <rect x="6" y="16" width="12" height="1" fill="currentColor" />
+        <line x1="12" y1="17" x2="12" y2="20" />
+        <line x1="9" y1="20" x2="15" y2="20" />
+        <rect x="7" y="7" width="4" height="3" rx="0.5" fill="currentColor" opacity="0.5" />
+        <line x1="12" y1="8" x2="16" y2="8" opacity="0.5" />
+        <line x1="12" y1="10" x2="15" y2="10" opacity="0.5" />
+      </svg>
+    )
+  }
+  
+  // Word files - document with text lines
+  if (ext === 'doc' || ext === 'docx') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
         <polyline points="14 2 14 8 20 8" />
-        <text x="7" y="17" fontSize="4.5" fontFamily="Arial, sans-serif" fill="currentColor" stroke="none">PDF</text>
+        <line x1="8" y1="13" x2="16" y2="13" opacity="0.6" />
+        <line x1="8" y1="16" x2="14" y2="16" opacity="0.6" />
+        <line x1="8" y1="10" x2="16" y2="10" opacity="0.6" />
+      </svg>
+    )
+  }
+  
+  // PDF files - updated design with circle badge
+  if (ext === 'pdf') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <circle cx="12" cy="14" r="4" opacity="0.7" />
+        <text x="9" y="16.5" fontSize="3.5" fontFamily="Arial, sans-serif" fill="currentColor" stroke="none">PDF</text>
+      </svg>
+    )
+  }
+  
+  // CSV files - simple table/grid icon
+  if (ext === 'csv') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="4" y="6" width="16" height="12" rx="1" />
+        <line x1="4" y1="10" x2="20" y2="10" />
+        <line x1="4" y1="14" x2="20" y2="14" />
+        <line x1="12" y1="6" x2="12" y2="18" />
+      </svg>
+    )
+  }
+  
+  // JSON/XML files - code brackets icon
+  if (ext === 'json' || ext === 'xml') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M8 3C6.5 3 6 4 6 5.5V8.5C6 10 5 10.5 3.5 10.5M3.5 13.5C5 13.5 6 14 6 15.5V18.5C6 20 6.5 21 8 21" />
+        <path d="M16 3C17.5 3 18 4 18 5.5V8.5C18 10 19 10.5 20.5 10.5M20.5 13.5C19 13.5 18 14 18 15.5V18.5C18 20 17.5 21 16 21" />
+      </svg>
+    )
+  }
+  
+  // Jupyter notebook files - notebook with code cells
+  if (ext === 'ipynb') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="5" y="2" width="14" height="20" rx="1" />
+        <line x1="5" y1="6" x2="19" y2="6" />
+        <line x1="5" y1="10" x2="19" y2="10" />
+        <line x1="5" y1="14" x2="19" y2="14" />
+        <circle cx="8" cy="4" r="0.5" fill="currentColor" />
+        <circle cx="10" cy="4" r="0.5" fill="currentColor" />
+        <line x1="7" y1="8" x2="17" y2="8" strokeWidth="0.5" opacity="0.6" />
+        <line x1="7" y1="12" x2="15" y2="12" strokeWidth="0.5" opacity="0.6" />
+      </svg>
+    )
+  }
+  
+  // Parquet files - columnar data structure icon
+  if (ext === 'parquet') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="4" y="4" width="3" height="16" rx="0.5" />
+        <rect x="8.5" y="8" width="3" height="12" rx="0.5" />
+        <rect x="13" y="6" width="3" height="14" rx="0.5" />
+        <rect x="17.5" y="10" width="3" height="10" rx="0.5" />
+      </svg>
+    )
+  }
+  
+  // ZIP archive icon - compressed folder
+  if (ext === 'zip') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M12 2v8l6 4v6a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-6l6-4V2z" />
+        <line x1="12" y1="2" x2="12" y2="4" strokeWidth="2" />
+        <line x1="12" y1="5" x2="12" y2="7" strokeWidth="2" />
+        <line x1="12" y1="8" x2="12" y2="10" strokeWidth="2" />
+      </svg>
+    )
+  }
+  
+  // Markdown icon - M with down arrow
+  if (ext === 'md') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <text x="6" y="16" fontSize="12" fontFamily="monospace, sans-serif" fill="currentColor" stroke="none" fontWeight="bold">M↓</text>
       </svg>
     )
   }
 
+  // Generic document icon (no custom icon)
   return (
     <svg xmlns="http://www.w3.org/2000/svg" className="file-type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />


### PR DESCRIPTION
## 🎯 Summary

Implements custom SVG icons for various file types to enhance visual file identification in the R2 Manager interface. This addresses issue #35 by replacing generic document icons with distinctive, recognizable icons for each file type.

## ✨ Changes

### New Custom Icons
- **Excel** (`.xls`, `.xlsx`): Spreadsheet with grid pattern
- **PowerPoint** (`.ppt`, `.pptx`): Presentation slide with projector stand
- **Word** (`.doc`, `.docx`): Document with text lines
- **PDF**: Enhanced design with circle badge
- **CSV**: Simple table grid
- **JSON/XML**: Code brackets
- **Jupyter Notebooks** (`.ipynb`): Notebook with code cells
- **Parquet**: Columnar data structure bars
- **ZIP**: Compressed folder with zipper visual
- **Markdown** (`.md`): M↓ symbol

### Technical Improvements
- Updated CSS for consistent icon rendering with rounded edges
- All icons use `currentColor` for theme compatibility
- Maintained existing image/video preview functionality
- Generic document icon displays for unknown file types

## 🧪 Testing

- ✅ Linting checks passed (`npm run lint`)
- ✅ All file types display appropriate custom icons
- ✅ Images continue to show previews (not replaced with icons)
- ✅ Videos continue to show video player (not replaced with icons)
- ✅ Generic icon displays for unknown file types

## 📋 Closes

Closes #35

## 📸 Preview

Custom icons are now instantly recognizable:
- Spreadsheets show a clear grid pattern
- Presentations show a slide with stand
- Documents show text lines
- Data files show appropriate structural visualizations
- Archives show compression visual cues

## ⚡ Performance

- Pure SVG implementation - no external assets
- Minimal performance impact
- Icons render inline with no additional HTTP requests