### PR TITLE
v3.4.3 - Fix Docker Hub description sync workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -227,7 +227,7 @@ jobs:
       deployments: write
 
     environment:
-      name: ${{ github.ref == 'refs/heads/main' && 'production' || '' }}
+      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || '' }}
       url: https://hub.docker.com/r/writenotenow/r2-bucket-manager
 
     steps:
@@ -287,7 +287,7 @@ jobs:
 
       # Update Docker Hub description
       - name: Update Docker Hub Description
-        if: github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: peter-evans/dockerhub-description@v5
         continue-on-error: true
         timeout-minutes: 5
@@ -299,7 +299,7 @@ jobs:
           short-description: "Cloudflare R2 Manager - Batch Ops, Cross-Bucket Search, Share Links, S3 Import, Tags, GitHub SSO."
 
       - name: Deployment Summary
-        if: github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "✅ Successfully published Docker images to production"
           echo "🐳 Registry: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [3.4.3] - 2026-03-07
+
+### CI/CD
+
+- **Docker Publishing** - Fixed conditionals in `docker-publish.yml` that prevented the Docker Hub README and Deployment Summary steps from executing on tag pushes
+
+---
+
 ## [3.4.2] - 2026-03-07
 
 ### Security

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -5,7 +5,7 @@
 A modern web application for managing Cloudflare R2 buckets with enterprise-grade authentication via Cloudflare Access Zero Trust.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-v3.4.2-green)
+![Version](https://img.shields.io/badge/version-v3.4.3-green)
 ![Status](https://img.shields.io/badge/status-Production%2FStable-brightgreen)
 [![Security](https://img.shields.io/badge/Security-Enhanced-green.svg)](https://github.com/neverinfamous/R2-Manager-Worker/blob/main/SECURITY.md)
 [![CodeQL](https://img.shields.io/badge/CodeQL-Passing-brightgreen.svg)](https://github.com/neverinfamous/R2-Manager-Worker/security/code-scanning)
@@ -152,13 +152,13 @@ docker run -p 8787:8787 -v "/path/to/wrangler.toml:/app/wrangler.toml" writenote
 | Tag           | Description                | Use Case                    |
 | ------------- | -------------------------- | --------------------------- |
 | `latest`      | Latest stable release      | **Recommended for testing** |
-| `v3.4.2`      | Specific version           | Pin to exact version        |
+| `v3.4.3`      | Specific version           | Pin to exact version        |
 | `sha-abc1234` | Commit SHA (12-char short) | Development/traceability    |
 
 **Pull a specific version:**
 
 ```bash
-docker pull writenotenow/r2-bucket-manager:v3.4.2
+docker pull writenotenow/r2-bucket-manager:v3.4.3
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A modern web application for managing Cloudflare R2 buckets with enterprise-grade authentication via Cloudflare Access Zero Trust.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-v3.4.2-green)
+![Version](https://img.shields.io/badge/version-v3.4.3-green)
 ![Status](https://img.shields.io/badge/status-Production%2FStable-brightgreen)
 [![Security](https://img.shields.io/badge/Security-Enhanced-green.svg)](https://github.com/neverinfamous/R2-Manager-Worker/blob/main/SECURITY.md)
 [![CodeQL](https://img.shields.io/badge/CodeQL-Passing-brightgreen.svg)](https://github.com/neverinfamous/R2-Manager-Worker/security/code-scanning)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "r2",
-  "version": "3.4.1",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "r2",
-      "version": "3.4.1",
+      "version": "3.4.3",
       "dependencies": {
         "jose": "^6.2.0",
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "r2",
   "private": true,
-  "version": "3.4.2",
+  "version": "3.4.3",
   "type": "module",
   "engines": {
     "node": ">=24.0.0"

--- a/releases/v3.4.3.md
+++ b/releases/v3.4.3.md
@@ -1,0 +1,13 @@
+# 🎉 R2 Bucket Manager v3.4.3 - Patch Release
+
+This patch release fixes a CI/CD workflow bug that prevented Docker deployments from updating the Docker Hub README on successful tag pushes.
+
+## CI/CD
+
+- **Docker Publishing** - Fixed conditionals in `docker-publish.yml` that prevented the Docker Hub README and Deployment Summary steps from executing on tag pushes
+
+---
+
+### Comparison
+
+[Compare v3.4.2 to v3.4.3](https://github.com/neverinfamous/R2-Manager-Worker/compare/v3.4.2...v3.4.3)


### PR DESCRIPTION
# 🎉 R2 Bucket Manager v3.4.3 - Patch Release

This patch release fixes a CI/CD workflow bug that prevented Docker deployments from updating the Docker Hub README on successful tag pushes.

## CI/CD

- **Docker Publishing** - Fixed conditionals in `docker-publish.yml` that prevented the Docker Hub README and Deployment Summary steps from executing on tag pushes

---

### Comparison

[Compare v3.4.2 to v3.4.3](https://github.com/neverinfamous/R2-Manager-Worker/compare/v3.4.2...v3.4.3)
